### PR TITLE
feat: Add support for glTF 2.0 file processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ ndarray = { version = "0.15", git = "https://github.com/3Dpass/ndarray", branch 
 peroxide = { version = "0.30", git = "https://github.com/3Dpass/Peroxide", branch = "devel", default-features = false }
 sha2 = { version = "0.10.6", default-features = false }
 base16ct = { version = "0.2.0", default-features = false }
+gltf = { version = "1", default-features = false }


### PR DESCRIPTION
Integrates the `gltf` crate to enable parsing and processing of .gltf (JSON) and .glb (binary) files alongside existing OBJ support.

Key changes:
- Added `gltf` crate (version 1) to dependencies.
- Introduced `InputFileType` enum (Obj, Gltf, Glb) to differentiate file formats in the processing pipeline.
- Modified `p3d_process` and `p3d_process_n` to accept `InputFileType`.
- Implemented logic to parse glTF/GLB files, extract vertex positions (converted to f64) and indices (as u32) from the first valid mesh primitive.
- Added `P3DError::GltfError` for specific glTF parsing errors.
- Included a test case using `test-ht.glb` to verify successful loading and processing of a GLB file.
- Added unit tests for malformed glTF/GLB data and for glTF files lacking renderable geometry to ensure robust error handling.

The system now correctly identifies and processes .obj, .gltf, and .glb files, feeding their geometry data into the existing mesh analysis algorithms.